### PR TITLE
FIX: Reconcile README and install.sh

### DIFF
--- a/README
+++ b/README
@@ -12,10 +12,12 @@ STEP 1: Install dependecies using the install scripts.
 
 From the root directory, just run;
 
-./install.sh
+DRIVERS=1 ./install.sh
 
 This script will install all required packages via apt-get and by installing other
 dependencies contained in the external folder.
+
+Subsequent installs can omit the "DRIVERS=1"
 
 ===================================================================================
 
@@ -23,7 +25,7 @@ STEP 2: Compile Vulcan code.
 
 1) To compile the code, type in the Vulcan root directory:
 
-        scons (scons -c for cleaning, scons -jx with x=number of jobs)
+        ninja -C build install
 
 2) To view the code documentation, type in ./src
 
@@ -92,7 +94,7 @@ architecture.
 
 To use this jar file:
 
-1) Build the code as normal via scons.
+1) Build the code as normal.
 2) Run from the root directory in a terminal:
     source setenv.sh
 3) Run lcm-spy from this terminal.

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ echo "Installing Vulcan from"$DIR
 echo "To install drivers for using the Vulcan wheelchair, set the DRIVERS environment variable:  DRIVERS=1 \
  $DIR/install.sh"
 
-sudo apt install -y build-essential meson ninja-build ccache wget liblcm-dev googletest doxygen texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
+sudo apt install -y build-essential meson ninja-build ccache wget liblcm-dev googletest doxygen graphviz texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
 
 EXTERNAL_DIR=$DIR/external
 LIB_DIR=$EXTERNAL_DIR/lib


### PR DESCRIPTION
Made several changes to README and install.sh so that following the instructions verbatim will get you to compiling on Ubuntu 20.04. LCM is still unusable in the current JRE though. (EDIT: Fixed in next PR)