### PR TITLE
 FIX: lcm<-->Java dependencies

### DIFF
--- a/README
+++ b/README
@@ -12,10 +12,12 @@ STEP 1: Install dependecies using the install scripts.
 
 From the root directory, just run;
 
-./install.sh
+DRIVERS=1 ./install.sh
 
 This script will install all required packages via apt-get and by installing other
 dependencies contained in the external folder.
+
+Subsequent installs can omit the "DRIVERS=1"
 
 ===================================================================================
 
@@ -23,7 +25,7 @@ STEP 2: Compile Vulcan code.
 
 1) To compile the code, type in the Vulcan root directory:
 
-        scons (scons -c for cleaning, scons -jx with x=number of jobs)
+        ninja -C build install
 
 2) To view the code documentation, type in ./src
 
@@ -92,7 +94,7 @@ architecture.
 
 To use this jar file:
 
-1) Build the code as normal via scons.
+1) Build the code as normal.
 2) Run from the root directory in a terminal:
     source setenv.sh
 3) Run lcm-spy from this terminal.

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ echo "Installing Vulcan from"$DIR
 echo "To install drivers for using the Vulcan wheelchair, set the DRIVERS environment variable:  DRIVERS=1 \
  $DIR/install.sh"
 
-sudo apt install -y build-essential meson ninja-build ccache wget liblcm-dev googletest doxygen graphviz texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
+sudo apt install -y build-essential meson ninja-build ccache wget default-jdk liblcm-dev liblcm-java libjchart2d-java googletest doxygen graphviz texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
 
 EXTERNAL_DIR=$DIR/external
 LIB_DIR=$EXTERNAL_DIR/lib
@@ -17,6 +17,10 @@ cd $EXTERNAL_DIR
 mkdir include
 mkdir lib
 mkdir pkgconfig
+
+# Get JVM if not already there and clean up lcm java bits to run on current JVM
+java --version || sudo apt install default-jdk
+sudo sed -i 's/ -Xincgc / /g' `which lcm-spy` `which lcm-logplayer-gui`
 
 # FIX for libarmadillo-dev not including a pkg-config (fixed upstream)
 cp armadillo.pc $PKG_CONFIG_DIR

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ echo "Installing Vulcan from"$DIR
 echo "To install drivers for using the Vulcan wheelchair, set the DRIVERS environment variable:  DRIVERS=1 \
  $DIR/install.sh"
 
-sudo apt install -y build-essential meson ninja-build ccache wget liblcm-dev googletest doxygen texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
+sudo apt install -y build-essential meson ninja-build ccache wget liblcm-dev googletest doxygen graphviz texlive-latex-extra libboost-all-dev libarmadillo-dev libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libusb-dev libusb-1.0-0-dev libpopt-dev libsdl1.2-dev libsdl-net1.2-dev libopencv-dev libf2c2-dev cmake;
 
 EXTERNAL_DIR=$DIR/external
 LIB_DIR=$EXTERNAL_DIR/lib


### PR DESCRIPTION
lcm-spy and lcm-logplayer-gui rely on java and had bad
command line options for current JVM's. lcm-spy also requires
jchart2d.

Solution: Install java, liblcm-java, and jchart2d. Patch out the arguments.