### PR TITLE
Turn on C++20, improve angle functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('vulcan', 'cpp', 'c',
-    default_options : ['cpp_std=c++17'])
+    default_options : ['cpp_std=c++20'])
 
 add_project_arguments('-Wno-non-virtual-dtor', #needed to compile cereal
                       '-Wno-unused-parameter',  # needed for LCM handlers and elsewhere

--- a/src/core/angle_functions.h
+++ b/src/core/angle_functions.h
@@ -10,10 +10,16 @@
 #ifndef CORE_ANGLE_FUNCTIONS_H
 #define CORE_ANGLE_FUNCTIONS_H
 
+#include <numbers>
 #include <cmath>
 
 namespace vulcan
 {
+
+constexpr float PI_F = std::numbers::pi_v<float>;
+constexpr float TWO_PI_F = 2.0f * PI_F;
+constexpr float PI_2_F = PI_F / 2.0f;
+constexpr float PI_4_F = PI_F / 4.0f;
 
 /**
  * wrap_to_pi takes an angle of arbitrary size and reduces it to the range [-PI, PI].
@@ -21,13 +27,17 @@ namespace vulcan
  * \param    angle           Angle to wrap
  * \return   Equivalent angle in range [-PI, PI].
  */
-inline float wrap_to_pi(float angle)
+template <typename T>
+T wrap_to_pi(T angle)
 {
-    if (angle < -M_PI) {
-        for (; angle < -M_PI; angle += 2.0 * M_PI)
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto TWO_PI = T(2) * PI;
+
+    if (angle < -PI) {
+        for (; angle < -PI; angle += TWO_PI)
             ;
-    } else if (angle > M_PI) {
-        for (; angle > M_PI; angle -= 2.0 * M_PI)
+    } else if (angle > PI) {
+        for (; angle > PI; angle -= TWO_PI)
             ;
     }
 
@@ -40,13 +50,17 @@ inline float wrap_to_pi(float angle)
  * \param    angle           Angle to wrap
  * \return   Equivalent angle in range [0, 2PI].
  */
-inline float wrap_to_2pi(float angle)
+template <typename T>
+T wrap_to_2pi(T angle)
 {
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto TWO_PI = T(2) * PI;
+
     if (angle < 0) {
-        for (; angle < 0; angle += 2.0 * M_PI)
+        for (; angle < 0; angle += TWO_PI)
             ;
-    } else if (angle > 2 * M_PI) {
-        for (; angle > 2 * M_PI; angle -= 2.0 * M_PI)
+    } else if (angle > TWO_PI) {
+        for (; angle > TWO_PI; angle -= TWO_PI)
             ;
     }
 
@@ -61,14 +75,18 @@ inline float wrap_to_2pi(float angle)
  * \param    angle           Angle to wrap
  * \return   Angle in the range [-pi/2,pi/2].
  */
-inline float wrap_to_pi_2(float angle)
+template <typename T>
+T wrap_to_pi_2(T angle)
 {
-    float wrapped = wrap_to_pi(angle);
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto PI_2 = PI / T(2);
 
-    if (wrapped < -M_PI_2) {
-        wrapped += M_PI;
-    } else if (wrapped > M_PI_2) {
-        wrapped -= M_PI;
+    T wrapped = wrap_to_pi(angle);
+
+    if (wrapped < -PI_2) {
+        wrapped += PI;
+    } else if (wrapped > PI_2) {
+        wrapped -= PI;
     }
 
     return wrapped;
@@ -82,11 +100,15 @@ inline float wrap_to_pi_2(float angle)
  * \param    rightAngle          Angle on the right-handside of the '-'
  * \return   The difference between the angles, leftAngle - rightAngle, in the range [-PI, PI].
  */
-inline double angle_diff(double leftAngle, double rightAngle)
+template <typename T>
+T angle_diff(T leftAngle, T rightAngle)
 {
-    double diff = leftAngle - rightAngle;
-    if (fabs(diff) > M_PI) {
-        diff -= (diff > 0) ? M_PI * 2 : M_PI * -2;
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto TWO_PI = T(2) * PI;
+
+    T diff = leftAngle - rightAngle;
+    if (std::abs(diff) > PI) {
+        diff -= (diff > 0) ? TWO_PI : -TWO_PI;
     }
 
     return diff;
@@ -100,9 +122,10 @@ inline double angle_diff(double leftAngle, double rightAngle)
  * \param    rightAngle          Angle on the right-handside of the '-'
  * \return   The absolute value of the difference between the angles, leftAngle - rightAngle, in the range [0, PI].
  */
-inline double angle_diff_abs(double leftAngle, double rightAngle)
+template <typename T>
+T angle_diff_abs(T leftAngle, T rightAngle)
 {
-    return fabs(angle_diff(leftAngle, rightAngle));
+    return std::abs(angle_diff(leftAngle, rightAngle));
 }
 
 
@@ -116,11 +139,15 @@ inline double angle_diff_abs(double leftAngle, double rightAngle)
  * \param    rhs         Angle on right of '-'
  * \return   lhs - rhs, in the range [0, PI/2].
  */
-inline double angle_diff_abs_pi_2(double lhs, double rhs)
+template <typename T>
+T angle_diff_abs_pi_2(T lhs, T rhs)
 {
-    double diff = std::abs(angle_diff(lhs, rhs));
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto PI_2 = PI / T(2);
 
-    return (diff < M_PI / 2.0) ? diff : M_PI - diff;
+    T diff = std::abs(angle_diff(lhs, rhs));
+
+    return (diff < PI_2) ? diff : PI - diff;
 }
 
 
@@ -131,12 +158,16 @@ inline double angle_diff_abs_pi_2(double lhs, double rhs)
  * \param    angleB              Second angle in the sum
  * \return   The sum of the two angles, angleA + angleB, in the range [-PI, PI].
  */
-inline double angle_sum(double angleA, double angleB)
+template <typename T>
+T angle_sum(T angleA, T angleB)
 {
-    double sum = angleA + angleB;
+    constexpr auto PI = std::numbers::pi_v<T>;
+    constexpr auto TWO_PI = T(2) * PI;
 
-    if (fabs(sum) > M_PI) {
-        sum -= (sum > 0) ? M_PI * 2 : M_PI * -2;
+    T sum = angleA + angleB;
+
+    if (std::abs(sum) > PI) {
+        sum -= (sum > 0) ? TWO_PI : -TWO_PI;
     }
 
     return sum;

--- a/src/core/line.h
+++ b/src/core/line.h
@@ -97,7 +97,7 @@ double length(const Line<T>& line)
  * \return   The slope of the line. If the line is vertical, then HUGE_VAL is returned.
  */
 template <typename T>
-double slope(const Line<T>& line)
+T slope(const Line<T>& line)
 {
     if (line.a.x == line.b.x) {
         return HUGE_VAL;
@@ -112,7 +112,7 @@ double slope(const Line<T>& line)
  * \return   atan2(b.y-a.y, b.x-a.x)
  */
 template <typename T>
-double direction(const Line<T>& line)
+T direction(const Line<T>& line)
 {
     return angle_to_point(line.a, line.b);
 }

--- a/src/core/point.h
+++ b/src/core/point.h
@@ -72,7 +72,7 @@ struct Point
  * distance_between_points calculates the Cartesian distance between two points.
  */
 template <typename T, typename U>
-float distance_between_points(T pointAx, T pointAy, U pointBx, U pointBy)
+T distance_between_points(T pointAx, T pointAy, U pointBx, U pointBy)
 {
     return std::sqrt((pointAx - pointBx) * (pointAx - pointBx) + (pointAy - pointBy) * (pointAy - pointBy));
 }
@@ -81,7 +81,7 @@ float distance_between_points(T pointAx, T pointAy, U pointBx, U pointBy)
  * distance_between_points calculates the Cartesian distance between two points.
  */
 template <typename T, typename U>
-float distance_between_points(const Point<T>& pointA, const Point<U>& pointB)
+T distance_between_points(const Point<T>& pointA, const Point<U>& pointB)
 {
     return std::sqrt((pointA.x - pointB.x) * (pointA.x - pointB.x) + (pointA.y - pointB.y) * (pointA.y - pointB.y));
 }
@@ -90,13 +90,13 @@ float distance_between_points(const Point<T>& pointA, const Point<U>& pointB)
  * distance_to_point calculates the radial distance from the origin to the specified point.
  */
 template <typename T>
-float distance_to_point(const Point<T>& point)
+T distance_to_point(const Point<T>& point)
 {
     return std::sqrt(point.x * point.x + point.y * point.y);
 }
 
 template <typename T, typename U>
-float squared_point_distance(const Point<T>& pointA, const Point<U>& pointB)
+T squared_point_distance(const Point<T>& pointA, const Point<U>& pointB)
 {
     return (pointA.x - pointB.x) * (pointA.x - pointB.x) + (pointA.y - pointB.y) * (pointA.y - pointB.y);
 }
@@ -137,19 +137,21 @@ T inner_product_between_points(const Point<T>& pointA, const Point<T>& pointB)
  * \return   Angle between first and second in the range of [0, PI]. NAN if first == center or second == center.
  */
 template <typename T>
-float angle_between_points(const Point<T>& first, const Point<T>& second, const Point<T>& center)
+auto angle_between_points(const Point<T>& first, const Point<T>& second, const Point<T>& center) -> std::common_type_t<T, float>
 {
     // Use the vector form here to get a pretty answer:
     //  cos(theta) = a dot b / ||a||*||b||
+
+    using Value = std::common_type_t<T, float>;
 
     if ((first == center) || (second == center)) {
         return NAN;
     }
 
-    T xA = first.x - center.x;
-    T yA = first.y - center.y;
-    T xB = second.x - center.x;
-    T yB = second.y - center.y;
+    Value xA = first.x - center.x;
+    Value yA = first.y - center.y;
+    Value xB = second.x - center.x;
+    Value yB = second.y - center.y;
 
     double acosTerm = (xA * xB + yA * yB) / (std::sqrt(xA * xA + yA * yA) * std::sqrt(xB * xB + yB * yB));
     if (acosTerm < -1.0) {
@@ -170,7 +172,7 @@ float angle_between_points(const Point<T>& first, const Point<T>& second, const 
  * \return   Angle of vector atan2(to - from).
  */
 template <typename T, typename U>
-float angle_to_point(const Point<T>& from, const Point<U>& to)
+auto angle_to_point(const Point<T>& from, const Point<U>& to) -> std::common_type_t<T, U, float>
 {
     return std::atan2(to.y - from.y, to.x - from.x);
 }

--- a/src/core/pose.h
+++ b/src/core/pose.h
@@ -23,6 +23,7 @@
 #include "system/message_traits.h"
 #include <cstdint>
 #include <iosfwd>
+#include <numbers>
 
 namespace vulcan
 {
@@ -62,7 +63,7 @@ struct pose_t
     /**
      * flip rotates the pose by 180 degrees.
      */
-    pose_t flip(void) const { return pose_t(x, y, angle_sum(theta, M_PI)); }
+    pose_t flip(void) const { return pose_t(x, y, angle_sum(theta, PI_F)); }
 
     /**
      * transformToNewFrame applies a transform to the pose and returns the resulting pose.

--- a/src/hssh/local_topological/area_detection/gateways/classifier_based_generator.cpp
+++ b/src/hssh/local_topological/area_detection/gateways/classifier_based_generator.cpp
@@ -285,7 +285,7 @@ struct ClassifierBasedGenerator::Impl
         //         }
         //     }
 
-        double skeletonNormal = 0.0;
+        float skeletonNormal = 0.0f;
 
         // Use regionCells_ to get the appropriate possibilities
         auto bestSources = skeleton.getSourceCells(maxCell.x, maxCell.y);

--- a/src/hssh/local_topological/area_detection/gateways/gateway_utils.cpp
+++ b/src/hssh/local_topological/area_detection/gateways/gateway_utils.cpp
@@ -181,7 +181,7 @@ double gateway_normal_from_source_cells(cell_t cell, const VoronoiSkeletonGrid& 
             double angleBetweenSources = std::abs(angle_between_points(sources[n], sources[m], cell));
             if (angleBetweenSources > maxAngle) {
                 maxAngle = angleBetweenSources;
-                maxNormal = angle_sum(angle_to_point(sources[n], sources[m]), M_PI_2);
+                maxNormal = angle_sum(angle_to_point(sources[n], sources[m]), PI_F);
             }
         }
     }

--- a/src/hssh/local_topological/area_detection/labeling/area_creator.cpp
+++ b/src/hssh/local_topological/area_detection/labeling/area_creator.cpp
@@ -211,8 +211,8 @@ std::unique_ptr<LocalArea> AreaBuilder::createPathSegment(const proposal_info_t&
             endpoint.gateway = create_gateway_for_skeleton_cell(endpoint.point, info.grid, info.isovists);
 
             // If the gateways point the same direction, then flip them
-            if (angle_diff_abs(endpoint.gateway.direction(), angle_to_point(endpoint.point, otherEndpoint.point))
-                < M_PI_2) {
+            if (angle_diff_abs(static_cast<double>(endpoint.gateway.direction()),
+                               angle_to_point(endpoint.point, otherEndpoint.point)) < M_PI_2) {
                 endpoint.gateway.reverseDirections();
             }
             // Make sure this fake gateway is included in the complete list of gateways for the area
@@ -229,8 +229,8 @@ std::unique_ptr<LocalArea> AreaBuilder::createPathSegment(const proposal_info_t&
             }
 
             // If the gateways point the same direction, then flip them
-            if (angle_diff_abs(endpoint.gateway.direction(), angle_to_point(endpoint.point, otherEndpoint.point))
-                < M_PI_2) {
+            if (angle_diff_abs(static_cast<double>(endpoint.gateway.direction()),
+                               angle_to_point(endpoint.point, otherEndpoint.point)) < M_PI_2) {
                 endpoint.gateway.reverseDirections();
             }
 
@@ -402,7 +402,7 @@ Gateway create_outbound_gateway(const Gateway& g, Point<float> interiorPoint)
     // to the gateway. This ensures the direction of the gateway points away from the area because a direction pointing
     // into the area will be closer to pi.
 
-    auto interiorAngle = angle_to_point(interiorPoint, g.center());
+    float interiorAngle = angle_to_point(interiorPoint, g.center());
     auto leftAngleDiff = angle_diff_abs(interiorAngle, g.leftDirection());
     auto rightAngleDiff = angle_diff_abs(interiorAngle, g.rightDirection());
 
@@ -431,7 +431,7 @@ Gateway create_gateway_for_skeleton_cell(const Point<float>& skeletonCenter,
         return *gateway;
     }
 
-    direction = angle_sum(voronoi_direction(pointCell, grid).left, M_PI_2);
+    direction = angle_sum(voronoi_direction(pointCell, grid).left, PI_2_F);
 
     gateway = create_gateway_at_cell(pointCell, direction, -1, grid, minExtraDist);
     if (gateway) {

--- a/src/hssh/local_topological/area_detection/labeling/beam_star_builder.cpp
+++ b/src/hssh/local_topological/area_detection/labeling/beam_star_builder.cpp
@@ -114,7 +114,7 @@ SmallScaleStar BeamStarBuilder::buildStar(const std::vector<Gateway>& gateways,
 }
 
 
-int BeamStarBuilder::numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, double axisDirection) const
+int BeamStarBuilder::numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, float axisDirection) const
 {
     std::cerr << "STUB! BeamStarBuilder::areGatewaysAlignedToAxis() \n";
     return 0;

--- a/src/hssh/local_topological/area_detection/labeling/beam_star_builder.h
+++ b/src/hssh/local_topological/area_detection/labeling/beam_star_builder.h
@@ -49,7 +49,7 @@ public:
     SmallScaleStar buildStar(const std::vector<Gateway>& gateways,
                              const Point<float>& center,
                              const math::Rectangle<float>& boundary) const override;
-    int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, double axisDirection) const override;
+    int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, float axisDirection) const override;
     bool areGatewaysAligned(const Gateway& lhs, const Gateway& rhs, const Point<float>& center) const override;
 
 private:

--- a/src/hssh/local_topological/area_detection/labeling/hypothesis.h
+++ b/src/hssh/local_topological/area_detection/labeling/hypothesis.h
@@ -465,10 +465,10 @@ private:
     int id_;          // Unique identifier for this hypothesis -- to be applied to the AreaProposal
 
     CellVector cells_;
-    double length_;
-    double width_;   // mean width of all contained edges
-    double axisRatio_;
-    double axisDirection_;
+    float length_;
+    float width_;   // mean width of all contained edges
+    float axisRatio_;
+    float axisDirection_;
 
     std::unique_ptr<AreaExtent> extent_;
     Point<double> center_;                                    // center of extent

--- a/src/hssh/local_topological/area_detection/labeling/path_similarity_star_builder.cpp
+++ b/src/hssh/local_topological/area_detection/labeling/path_similarity_star_builder.cpp
@@ -37,7 +37,7 @@ namespace hssh
 
 math::Rectangle<float> boundary_around_gateways(const std::vector<Gateway>& gateways);
 double distance_similarity_score(const Gateway& gateway, double direction);
-double direction_towards_center(const Gateway& gateway, const Point<float>& center);
+float direction_towards_center(const Gateway& gateway, const Point<float>& center);
 local_path_fragment_t create_path_fragment(int index, float direction, const Gateway& gateway);
 
 
@@ -92,7 +92,7 @@ SmallScaleStar PathSimilarityStarBuilder::buildStar(const std::vector<Gateway>& 
 
 
 int PathSimilarityStarBuilder::numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways,
-                                                        double axisDirection) const
+                                                        float axisDirection) const
 {
     // Need at least two gateways for them to be aligned
     if (gateways.size() < 2) {
@@ -381,9 +381,9 @@ double distance_similarity_score(const Gateway& gateway, double direction)
 }
 
 
-double direction_towards_center(const Gateway& gateway, const Point<float>& center)
+float direction_towards_center(const Gateway& gateway, const Point<float>& center)
 {
-    double angleToCenter = angle_to_point(gateway.center(), center);
+    float angleToCenter = angle_to_point(gateway.center(), center);
     double leftDiff = angle_diff_abs(gateway.leftDirection(), angleToCenter);
     double rightDiff = angle_diff_abs(gateway.rightDirection(), angleToCenter);
     return (leftDiff < rightDiff) ? gateway.leftDirection() : gateway.rightDirection();

--- a/src/hssh/local_topological/area_detection/labeling/path_similarity_star_builder.h
+++ b/src/hssh/local_topological/area_detection/labeling/path_similarity_star_builder.h
@@ -73,7 +73,7 @@ public:
     SmallScaleStar buildStar(const std::vector<Gateway>& gateways,
                              const Point<float>& center,
                              const math::Rectangle<float>& boundary) const override;
-    int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, double axisDirection) const override;
+    int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, float axisDirection) const override;
     bool areGatewaysAligned(const Gateway& lhs, const Gateway& rhs, const Point<float>& center) const override;
 
 private:

--- a/src/hssh/local_topological/area_detection/labeling/small_scale_star_builder.h
+++ b/src/hssh/local_topological/area_detection/labeling/small_scale_star_builder.h
@@ -91,7 +91,7 @@ public:
      * \param    axisDirection       Direction of the axis of alignment
      * \return   Number of gateways aligned to the specified axis.
      */
-    virtual int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, double axisDirection) const = 0;
+    virtual int numGatewaysAlignedToAxis(const std::vector<Gateway>& gateways, float axisDirection) const = 0;
 
     /**
      * areGatewaysAligned asks if a pair of gateways are aligned. Aligned gateways do not necessarily belong to the same

--- a/src/hssh/local_topological/area_detection/voronoi/voronoi_utils.cpp
+++ b/src/hssh/local_topological/area_detection/voronoi/voronoi_utils.cpp
@@ -86,7 +86,7 @@ int follow_branch(const cell_t& startCell,
 template <class Iter>
 Iter extract_cells_along_edge(cell_t parent, cell_t child, const VoronoiSkeletonGrid& grid, Iter edgeOut);
 
-voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, double angleHint);
+voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, float angleHint);
 
 
 ////////////////////// Main functions ///////////////////////////////////////
@@ -614,13 +614,13 @@ Iter extract_cells_along_edge(cell_t parent, cell_t child, const VoronoiSkeleton
 }
 
 
-voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, double angleHint)
+voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, float angleHint)
 {
     assert(!trace.traces.empty());
 
-    double otherHint = angle_sum(angleHint, M_PI);
-    double minHintDist = 1000.0;
-    double minOtherDist = 1000.0;
+    float otherHint = angle_sum(angleHint, PI_F);
+    float minHintDist = 1000.0f;
+    float minOtherDist = 1000.0f;
 
     voronoi_directions_t directions = {angleHint, otherHint, minHintDist, minOtherDist};
 
@@ -630,7 +630,7 @@ voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, do
         }
 
         auto traceLine = math::total_least_squares(t.points.begin(), t.points.end());
-        double traceDirection = angle_to_point(traceLine.a, traceLine.b);
+        float traceDirection = angle_to_point(traceLine.a, traceLine.b);
 
         if (angle_diff_abs(traceDirection, angleHint) < minHintDist) {
             directions.left = traceDirection;
@@ -653,8 +653,8 @@ voronoi_directions_t find_directions_from_trace(const voronoi_trace_t& trace, do
         directions.right = otherHint;
     }
 
-    if (angle_diff_abs(directions.left, directions.right) < M_PI / 3.0) {
-        directions.right = angle_sum(directions.right, M_PI);
+    if (angle_diff_abs(directions.left, directions.right) < PI_F / 3.0f) {
+        directions.right = angle_sum(directions.right, PI_2_F);
     }
 
     return directions;

--- a/src/hssh/local_topological/area_detection/voronoi/voronoi_utils.h
+++ b/src/hssh/local_topological/area_detection/voronoi/voronoi_utils.h
@@ -69,11 +69,11 @@ struct voronoi_trace_t
 
 struct voronoi_directions_t
 {
-    double left;
-    double right;
+    float left;
+    float right;
 
-    double leftDist;    ///< Distance along skeleton the left direction was computed
-    double rightDist;   ///< Distance along skeleton the right direction was computed
+    float leftDist;    ///< Distance along skeleton the left direction was computed
+    float rightDist;   ///< Distance along skeleton the right direction was computed
 };
 
 /**

--- a/src/hssh/local_topological/gateway.cpp
+++ b/src/hssh/local_topological/gateway.cpp
@@ -213,10 +213,10 @@ bool Gateway::isSimilarTo(const Gateway& rhs) const
 void Gateway::calculateDirections(const VoronoiSkeletonGrid& grid, const VoronoiIsovistField* isovists)
 {
     // Use the skeleton to calculate the direction of the gateway
-    float normalAngle = angle_sum(vulcan::direction(boundary_), M_PI / 2.0f);
+    float normalAngle = angle_sum(vulcan::direction(boundary_), M_PI_2);
 
     leftDirection_ = normalAngle;
-    rightDirection_ = angle_sum(normalAngle, M_PI);
+    rightDirection_ = angle_sum(normalAngle, PI_F);
 
     auto skeletonDirections = voronoi_direction(skeletonCell_, grid, normalAngle);
 
@@ -250,7 +250,7 @@ void Gateway::calculateDirections(const VoronoiSkeletonGrid& grid, const Voronoi
     // Gateways closely track the normal in their construction, so don't let the direction change by too much
     if (angle_diff_abs_pi_2(leftDirection_, normalAngle) > M_PI / 36.0) {
         leftDirection_ = normalAngle;
-        rightDirection_ = angle_sum(normalAngle, M_PI);
+        rightDirection_ = angle_sum(normalAngle, PI_F);
     }
 }
 

--- a/src/hssh/metrical/localization/motion_model_distribution.cpp
+++ b/src/hssh/metrical/localization/motion_model_distribution.cpp
@@ -69,19 +69,19 @@ MotionModelDistribution::MotionModelDistribution(const odometry_t& startOdom,
         //         imuTheta *= -1;
     }
 
-    float odometryTheta = angle_diff(endOdom.theta, startOdom.theta);
+    double odometryTheta = angle_diff(endOdom.theta, startOdom.theta);
 
-    float deltaX = endOdom.x - startOdom.x;
-    float deltaY = endOdom.y - startOdom.y;
-    float deltaTheta = haveImu ? imuTheta : odometryTheta;
-    float direction = 1.0;
+    double deltaX = endOdom.x - startOdom.x;
+    double deltaY = endOdom.y - startOdom.y;
+    double deltaTheta = haveImu ? imuTheta : odometryTheta;
+    double direction = 1.0;
 
-    double trans = sqrt(deltaY * deltaY + deltaX * deltaX);
-    double rot1 = angle_diff(atan2(deltaY, deltaX), startOdom.theta);
+    double trans = std::sqrt(deltaY * deltaY + deltaX * deltaX);
+    double rot1 = angle_diff(std::atan2(deltaY, deltaX), startOdom.theta);
 
     if (std::abs(trans) < 0.00005) {
         rot1 = 0.0;
-    } else if (std::abs(rot1) > M_PI / 2.0) {
+    } else if (std::abs(rot1) > M_PI_2) {
         rot1 = angle_diff(M_PI, rot1);
         direction = -1.0;
     }

--- a/src/hssh/metrical/localization/particle_filter_utils.cpp
+++ b/src/hssh/metrical/localization/particle_filter_utils.cpp
@@ -190,14 +190,18 @@ Matrix calculate_sample_set_covariance(const std::vector<particle_t>& samples, c
     double sumWeightSquared = 0;
 
     for (int i = samples.size(); --i >= 0;) {
-        sigmaXX += samples[i].weight * pow(meanX - samples[i].pose.x, 2);
-        sigmaYY += samples[i].weight * pow(meanY - samples[i].pose.y, 2);
+        const double errX = meanX - samples[i].pose.x;
+        const double errY = meanY - samples[i].pose.y;
+        const double errTheta = angle_diff(meanTheta, static_cast<double>(samples[i].pose.theta));
 
-        sigmaXY += samples[i].weight * (meanX - samples[i].pose.x) * (meanY - samples[i].pose.y);
-        sigmaXTheta += samples[i].weight * (meanX - samples[i].pose.x) * angle_diff(meanTheta, samples[i].pose.theta);
-        sigmaYTheta += samples[i].weight * (meanY - samples[i].pose.y) * angle_diff(meanTheta, samples[i].pose.theta);
+        sigmaXX += samples[i].weight * errX * errX;
+        sigmaYY += samples[i].weight * errY * errY;
 
-        sigmaThetaTheta += samples[i].weight * pow(angle_diff(meanTheta, samples[i].pose.theta), 2);
+        sigmaXY += samples[i].weight * errX * errY;
+        sigmaXTheta += samples[i].weight * errX * errTheta;
+        sigmaYTheta += samples[i].weight * errY * errTheta;
+
+        sigmaThetaTheta += samples[i].weight * errTheta * errTheta;
         sumWeightSquared += samples[i].weight * samples[i].weight;
     }
 

--- a/src/hssh/types.h
+++ b/src/hssh/types.h
@@ -28,6 +28,7 @@
 #include "core/point_util.h"
 #include <cassert>
 #include <cstdint>
+#include <ostream>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/laser/line_extraction.cpp
+++ b/src/laser/line_extraction.cpp
@@ -433,7 +433,7 @@ extracted_lines_t vulcan::laser::angle_segmentation(const polar_laser_scan_t& sc
 
     // Need to check the distance from PI / 2 for the angles as the angle found is [0, PI], but I want only the curvy
     // spots
-    double threshAng = fabs(angle_diff(M_PI, params.thresholdAngleDegrees));
+    double threshAng = std::abs(angle_diff(PI_F, params.thresholdAngleDegrees));
     double curAngle = 0;
     double nextAngle = 0;
     double minAngle = M_PI;

--- a/src/laser/test/correlative_scan_matcher_test.cpp
+++ b/src/laser/test/correlative_scan_matcher_test.cpp
@@ -364,5 +364,5 @@ void do_odometry_update(pose_t& pose, const vulcan::Vector& delta)
 {
     pose.x += delta(X_INDEX);   // delta.deltaX * cos(delta.deltaTheta/2 + pose.theta);
     pose.y += delta(Y_INDEX);   // delta.deltaX * sin(delta.deltaTheta/2 + pose.theta);
-    pose.theta = vulcan::angle_sum(pose.theta, delta(THETA_INDEX));
+    pose.theta = vulcan::angle_sum(pose.theta, static_cast<float>(delta(THETA_INDEX)));
 }

--- a/src/logging/logplayer/carmen_reader.cpp
+++ b/src/logging/logplayer/carmen_reader.cpp
@@ -177,7 +177,7 @@ void CarmenReader::processOldLaserMessage(std::istringstream& message)
 
     if (havePreviousPose) {
         odom.translation = std::sqrt(std::pow((odom.x - previousPose.x), 2) + std::pow((odom.y - previousPose.y), 2));
-        odom.rotation = angle_diff(odom.theta, previousPose.theta);
+        odom.rotation = angle_diff(odom.theta, static_cast<double>(previousPose.theta));
     } else {
         odom.translation = 0.0;
         odom.rotation = 0.0;
@@ -258,7 +258,7 @@ void CarmenReader::processLaserMessage(std::istringstream& message)
     // then subtract off the robot pose to get the actual laser offset
     scan.offset.x = odom.x - scan.offset.x;
     scan.offset.y = odom.y - scan.offset.y;
-    scan.offset.theta = angle_diff(odom.theta, scan.offset.theta);
+    scan.offset.theta = angle_diff(odom.theta, static_cast<double>(scan.offset.theta));
 
     // Skip reading safety, velocity
     skipIt = std::istream_iterator<double>(message);   // tv
@@ -290,7 +290,7 @@ void CarmenReader::processLaserMessage(std::istringstream& message)
 
     if (havePreviousPose) {
         odom.translation = std::sqrt(std::pow((odom.x - previousPose.x), 2) + std::pow((odom.y - previousPose.y), 2));
-        odom.rotation = angle_diff(odom.theta, previousPose.theta);
+        odom.rotation = angle_diff(odom.theta, static_cast<double>(previousPose.theta));
     } else {
         odom.translation = 0.0;
         odom.rotation = 0.0;

--- a/src/math/geometry/rectangle_fitting.cpp
+++ b/src/math/geometry/rectangle_fitting.cpp
@@ -255,7 +255,7 @@ caliper_rotation_t find_minimum_caliper_rotation(rotating_calipers_state_t& stat
         int previousVertexIndex = previous_index(caliper.vertexIndex, state.hullVertices.size());
 
         // The calipers rotate clockwise around the polygon, so the caliper rotation is always negative or zero.
-        float hullAngle =
+        double hullAngle =
           angle_to_point(state.hullVertices[caliper.vertexIndex], state.hullVertices[previousVertexIndex]);
         float caliperRotation = angle_diff(hullAngle, caliper.angle);
 

--- a/src/mpepc/control/control_law_coordinates.h
+++ b/src/mpepc/control/control_law_coordinates.h
@@ -95,9 +95,9 @@ struct control_law_coordinates_t
                    == BACKWARD)   // flip the target and the robot pose when the direction of approach is backward.
         {
             float lineOfSightOrientation =
-              (r > SMALL_RADIUS_M) ? atan2(deltaY, deltaX) : angle_sum(targetPose.theta, M_PI);
-            theta = angle_diff(angle_sum(targetPose.theta, M_PI), lineOfSightOrientation);
-            delta = angle_diff(angle_sum(robotPose.theta, M_PI), lineOfSightOrientation);
+              (r > SMALL_RADIUS_M) ? std::atan2(deltaY, deltaX) : angle_sum(targetPose.theta, PI_F);
+            theta = angle_diff(angle_sum(targetPose.theta, PI_F), lineOfSightOrientation);
+            delta = angle_diff(angle_sum(robotPose.theta, PI_F), lineOfSightOrientation);
             r *= -1;
         } else {
             std::cout << "ERROR: Unknown direction of approach!\n";
@@ -107,24 +107,24 @@ struct control_law_coordinates_t
     pose_t toRobotPose(const pose_t& targetPose) const
     {
         float lineOfSightOrientation =
-          (r > 0.0) ? angle_diff(targetPose.theta, theta) : angle_diff(angle_sum(targetPose.theta, M_PI), theta);
+          (r > 0.0f) ? angle_diff(targetPose.theta, theta) : angle_diff(angle_sum(targetPose.theta, PI_F), theta);
         float robotOrientation =
-          (r > 0.0) ? angle_sum(lineOfSightOrientation, delta) : angle_sum(lineOfSightOrientation + M_PI, delta);
+          (r > 0.0f) ? angle_sum(lineOfSightOrientation, delta) : angle_sum(lineOfSightOrientation + PI_F, delta);
 
-        return pose_t(targetPose.x - fabs(r) * cos(lineOfSightOrientation),
-                      targetPose.y - fabs(r) * sin(lineOfSightOrientation),
+        return pose_t(targetPose.x - std::abs(r) * std::cos(lineOfSightOrientation),
+                      targetPose.y - std::abs(r) * std::sin(lineOfSightOrientation),
                       robotOrientation);
     }
 
     pose_t toTargetPose(const pose_t& robotPose) const
     {
         float lineOfSightOrientation =
-          (r > 0.0) ? angle_diff(robotPose.theta, delta) : angle_diff(angle_sum(robotPose.theta, M_PI), delta);
+          (r > 0.0f) ? angle_diff(robotPose.theta, delta) : angle_diff(angle_sum(robotPose.theta, PI_F), delta);
         float targetOrientation =
-          (r > 0.0) ? angle_sum(lineOfSightOrientation, theta) : angle_sum(lineOfSightOrientation + M_PI, theta);
+          (r > 0.0f) ? angle_sum(lineOfSightOrientation, theta) : angle_sum(lineOfSightOrientation + PI_F, theta);
 
-        return pose_t(robotPose.x + fabs(r) * cos(lineOfSightOrientation),
-                      robotPose.y + fabs(r) * sin(lineOfSightOrientation),
+        return pose_t(robotPose.x + std::abs(r) * std::cos(lineOfSightOrientation),
+                      robotPose.y + std::abs(r) * std::sin(lineOfSightOrientation),
                       targetOrientation);
     }
 };

--- a/src/mpepc/control/kinematic_control_law.cpp
+++ b/src/mpepc/control/kinematic_control_law.cpp
@@ -97,31 +97,31 @@ control_law_output_t KinematicControlLaw::computeOutput(const pose_t& robotPose,
         }
     } else   // normal update
     {
-        double kKappaThresh = 4.0;
+        const float kKappaThresh = 4.0f;
         //         double kSmallRadius = 0.15;
         //         double kLargeRadius = 2.0;
         //         double kMinLinearVelocity = 0.15;
         //         double kMaxLinearVelocity  = motionTarget.velocityGain;
 
-        double minimumForwardSpeed = 0.15;
+        const float minimumForwardSpeed = 0.15f;
 
-        double referenceDelta =
-          atan(-params_.k1 * coords.theta);   // robot reference heading in controller coordinates.
+        float referenceDelta =
+          std::atan(-params_.k1 * coords.theta);   // robot reference heading in controller coordinates.
 
         // determination of the control based on error kinematics
-        double propotionalControlTerm =
+        float propotionalControlTerm =
           params_.k2 * angle_diff(coords.delta, referenceDelta);   // I usually prefer (reference - current) for the
                                                                    // error, but well this is how it was published.
-        double feedforwardControlTerm =
-          sin(coords.delta) * (1.0 + (params_.k1 / (1.0 + pow(params_.k1 * coords.theta, 2.0))));
+        float feedforwardControlTerm =
+          std::sin(coords.delta) * (1.0f + (params_.k1 / (1.0f + std::pow(params_.k1 * coords.theta, 2.0f))));
 
-        double radiusTimesKappa = -(propotionalControlTerm + feedforwardControlTerm);
-        double referenceKappa = radiusTimesKappa / fabs(coords.r);
+        float radiusTimesKappa = -(propotionalControlTerm + feedforwardControlTerm);
+        float referenceKappa = radiusTimesKappa / std::abs(coords.r);
 
         double lambda = params_.lambda;
         double beta = params_.beta;
 
-        if (fabs(referenceKappa) > kKappaThresh) {
+        if (std::abs(referenceKappa) > kKappaThresh) {
             lambda = 1.0;
             beta = beta * pow(kKappaThresh, (params_.lambda - lambda));
         }
@@ -149,7 +149,7 @@ control_law_output_t KinematicControlLaw::computeOutput(const pose_t& robotPose,
                               // and the control law coordinates were computed from flipped robot and target pose.
         {
             output.linearVelocity *= -1;
-            output.referenceHeading = angle_sum(output.referenceHeading, M_PI);
+            output.referenceHeading = angle_sum(output.referenceHeading, PI_F);
         }
     }
 
@@ -224,7 +224,7 @@ control_law_output_t
     if (coords.r < 0)   // Flip reference heading and linear velocity if r < 0, since desired motion is backward and the
                         // control law coordinates were computed from flipped robot and target pose.
     {
-        output.referenceHeading = angle_sum(output.referenceHeading, M_PI);
+        output.referenceHeading = angle_sum(output.referenceHeading, PI_F);
     }
 
     return output;

--- a/src/mpepc/grid/visibility_analysis.cpp
+++ b/src/mpepc/grid/visibility_analysis.cpp
@@ -75,7 +75,7 @@ math::Polygon<double>
     auto origin = laserPose.toPoint();
 
     auto rotatedRange = laser.range;
-    rotatedRange.startAngle = angle_sum(rotatedRange.startAngle, laserPose.theta);
+    rotatedRange.startAngle = angle_sum(rotatedRange.startAngle, static_cast<double>(laserPose.theta));
 
     // Create the ray trace scan of the static environment
     PointVec<double> rays(rotatedRange.numIncrements + 2);

--- a/src/mpepc/manifold/navigation.cpp
+++ b/src/mpepc/manifold/navigation.cpp
@@ -447,7 +447,7 @@ double NavigationTaskManifold::getCostToGo(const motion_state_t& state) const
         costToGo = getCostToGoFromNavGrid(state);
 
         if (isUsingNavGradient_) {
-            double gradientHeading = computeNavGradient(state.pose);
+            float gradientHeading = computeNavGradient(state.pose);
             headingError = taskParams_.orientationHeuristicWeight * angle_diff_abs(gradientHeading, state.pose.theta);
         }
     } else {
@@ -522,7 +522,7 @@ double NavigationTaskManifold::calculateHeuristicCost(const robot_trajectory_inf
 }
 
 
-double NavigationTaskManifold::computeNavGradient(const pose_t& pose) const
+float NavigationTaskManifold::computeNavGradient(const pose_t& pose) const
 {
     // in other places follow the gradient of the navigation function, comupted by central gradient.
     // point to cell introduces error up to half grid size, which probably is tolerable.
@@ -535,7 +535,7 @@ double NavigationTaskManifold::computeNavGradient(const pose_t& pose) const
     float dx =
       (navGrid_.getCostToGo(Point<int>(cell.x - 1, cell.y)) - navGrid_.getCostToGo(Point<int>(cell.x + 1, cell.y)));
 
-    return atan2(dy, dx);
+    return std::atan2(dy, dx);
 }
 
 

--- a/src/mpepc/manifold/navigation.h
+++ b/src/mpepc/manifold/navigation.h
@@ -106,7 +106,7 @@ private:
 
     double getCostToGoFromNavGrid(const motion_state_t& state) const;
 
-    double computeNavGradient(const pose_t& pose) const;
+    float computeNavGradient(const pose_t& pose) const;
 };
 
 }   // namespace mpepc

--- a/src/mpepc/manifold/rotate.cpp
+++ b/src/mpepc/manifold/rotate.cpp
@@ -23,7 +23,7 @@ namespace vulcan
 namespace mpepc
 {
 
-RotateTaskManifold::RotateTaskManifold(double orientation)
+RotateTaskManifold::RotateTaskManifold(float orientation)
 : mode_(RotationMode::fixed_orientation)
 , orientation_(wrap_to_pi(orientation))   // wrap to ensure the angle is within the [-pi,pi] range
 {
@@ -41,9 +41,9 @@ void RotateTaskManifold::update(const planning_environment_t& env,
 {
     // In turn left or turn right mode, the goal orientation constantly moves away from the robot.
     if (mode_ == RotationMode::turn_left) {
-        orientation_ = angle_sum(env.robotState.pose.theta, M_PI_2);
+        orientation_ = angle_sum(env.robotState.pose.theta, PI_2_F);
     } else if (mode_ == RotationMode::turn_right) {
-        orientation_ = angle_diff(env.robotState.pose.theta, M_PI_2);
+        orientation_ = angle_diff(env.robotState.pose.theta, PI_2_F);
     }
     // Otherwise, the goal orientation is fixed
 

--- a/src/mpepc/manifold/rotate.h
+++ b/src/mpepc/manifold/rotate.h
@@ -42,7 +42,7 @@ public:
      *
      * \param    orientation         Desired orientation for the robot to reach
      */
-    explicit RotateTaskManifold(double orientation);
+    explicit RotateTaskManifold(float orientation);
 
     /**
      * Constructor for RotateTaskManifold.
@@ -68,7 +68,7 @@ public:
 
 private:
     RotationMode mode_;
-    double orientation_;
+    float orientation_;
     pose_t targetPose_;   // if the robot were to turn perfect in-place, where would it end up?s
 };
 

--- a/src/mpepc/metric_planner/task/rotate.cpp
+++ b/src/mpepc/metric_planner/task/rotate.cpp
@@ -28,13 +28,13 @@ namespace mpepc
 
 //////////////////////// RotateTask implementation /////////////////////////////////////
 
-RotateTask::RotateTask(double goalOrientation, double maxCompletionError)
+RotateTask::RotateTask(float goalOrientation, float maxCompletionError)
 : id_(utils::system_time_us())
 , mode_(RotationMode::fixed_orientation)
 , orientation_(goalOrientation)
 , maxError_(maxCompletionError)
 {
-    assert(maxCompletionError > 0.0);
+    assert(maxCompletionError > 0);
 }
 
 

--- a/src/mpepc/metric_planner/task/rotate.h
+++ b/src/mpepc/metric_planner/task/rotate.h
@@ -44,7 +44,7 @@ public:
      *                               considered complete (optional, default = 0.05 (about 3 degrees))
      * \pre  maxCompletionError > 0
      */
-    explicit RotateTask(double goalOrientation, double maxCompletionError = 0.05);
+    explicit RotateTask(float goalOrientation, float maxCompletionError = 0.05f);
 
     /**
      * Constructor for RotateTask.
@@ -67,8 +67,8 @@ public:
 private:
     Id id_;
     RotationMode mode_;
-    double orientation_;
-    double maxError_;
+    float orientation_;
+    float maxError_;
 
     // Serialization support
     friend class cereal::access;

--- a/src/mpepc/motion_controller/waypoint_follower/graceful_motion_control_law.cpp
+++ b/src/mpepc/motion_controller/waypoint_follower/graceful_motion_control_law.cpp
@@ -149,7 +149,7 @@ void GracefulMotionControlLaw::setTargetPose(const pose_t& pose,
     this->params = params;
 
     if (direction == GRACEFUL_MOTION_BACKWARD) {
-        target.theta = angle_sum(target.theta, M_PI);
+        target.theta = angle_sum(target.theta, PI_F);
     }
 
 #ifdef DEBUG_TARGET
@@ -173,7 +173,7 @@ graceful_motion_output_t GracefulMotionControlLaw::apply(const motion_state_t& c
 
     // If not moving forward, then flip the pose to be used for calculating the controls
     float theta =
-      (direction == GRACEFUL_MOTION_FORWARD) ? currentState.pose.theta : angle_sum(currentState.pose.theta, M_PI);
+      (direction == GRACEFUL_MOTION_FORWARD) ? currentState.pose.theta : angle_sum(currentState.pose.theta, PI_F);
     pose_t currentPose{currentState.pose.x, currentState.pose.y, theta};
 
     float deltaTheta = angle_diff(target.theta, currentPose.theta);

--- a/src/mpepc/rrt/unicycle_lyapunov_steering.cpp
+++ b/src/mpepc/rrt/unicycle_lyapunov_steering.cpp
@@ -101,10 +101,10 @@ pose_t UnicycleLyapunovSteering::incrementalRotation(const pose_t& robotPose,
     pose_t nextPose = robotPose;
 
     // find reference heading induced by the laypunov function
-    double referenceHeading = lyap.stabilizingHeading(robotPose.toPoint());
-    double headingError = angle_diff(referenceHeading, robotPose.theta);
+    float referenceHeading = lyap.stabilizingHeading(robotPose.toPoint());
+    float headingError = angle_diff(referenceHeading, robotPose.theta);
 
-    if (fabs(headingError) > maxRotation) {
+    if (std::abs(headingError) > maxRotation) {
         *isAligned = false;
         nextPose.theta = nextPose.theta + copysign(maxRotation, headingError);
     } else {

--- a/src/mpepc/social/social_norm_utils.cpp
+++ b/src/mpepc/social/social_norm_utils.cpp
@@ -220,9 +220,9 @@ double normalized_position_path(const topo_agent_t& agent, const hssh::LocalTopo
     // If the goal isn't one of the ends, but a destination, then use the heading information to try and
     // determine which gateway to use.
     else {
-        double agentHeading = std::atan2(agent.state.yVel, agent.state.xVel);
-        double plusDiff = angle_diff_abs(agentHeading, plusGwy.direction());
-        double minusDiff = angle_diff_abs(agentHeading, minusGwy.direction());
+        float agentHeading = std::atan2(agent.state.yVel, agent.state.xVel);
+        float plusDiff = angle_diff_abs(agentHeading, plusGwy.direction());
+        float minusDiff = angle_diff_abs(agentHeading, minusGwy.direction());
 
         startCell = (plusDiff > minusDiff) ? plusGwy.skeletonCell() : minusGwy.skeletonCell();
     }

--- a/src/robot/model/robot_plant_model.cpp
+++ b/src/robot/model/robot_plant_model.cpp
@@ -41,12 +41,12 @@ pose_t RobotPlantModel::turnDriveTurnIntegration(const pose_t& priorPose,
                                                  const velocity_t& averageVelocity,
                                                  const float timestep)
 {
-    float halfDeltaTheta = averageVelocity.angular * timestep * 0.5;
+    float halfDeltaTheta = averageVelocity.angular * timestep * 0.5f;
     float travelDistance = averageVelocity.linear * timestep;
 
     return pose_t(priorPose.x + travelDistance * cos(priorPose.theta + halfDeltaTheta),
                   priorPose.y + travelDistance * sin(priorPose.theta + halfDeltaTheta),
-                  angle_sum(priorPose.theta, halfDeltaTheta * 2.0));
+                  angle_sum(priorPose.theta, halfDeltaTheta * 2.0f));
 }
 
 

--- a/src/sensors/wheel_encoders.cpp
+++ b/src/sensors/wheel_encoders.cpp
@@ -123,8 +123,8 @@ void WheelEncoders::calculateWheelMotion(void)
 
 void WheelEncoders::calculateDeadReckoningPose(void)
 {
-    float distance = (currentEncoders.deltaLeftWheel + currentEncoders.deltaRightWheel) / 2;
-    float rotation = (currentEncoders.deltaRightWheel - currentEncoders.deltaLeftWheel) / currentEncoders.wheelbase;
+    const double distance = (currentEncoders.deltaLeftWheel + currentEncoders.deltaRightWheel) * 0.5;
+    const double rotation = (currentEncoders.deltaRightWheel - currentEncoders.deltaLeftWheel) / currentEncoders.wheelbase;
 
     cumulative.x += distance * std::cos(cumulative.theta + rotation / 2);
     cumulative.y += distance * std::sin(cumulative.theta + rotation / 2);

--- a/src/ui/components/occupancy_grid_renderer.h
+++ b/src/ui/components/occupancy_grid_renderer.h
@@ -19,6 +19,7 @@
 
 #include "core/point.h"
 #include <array>
+#include <cstdint>
 
 namespace vulcan
 {

--- a/src/utils/isovist.cpp
+++ b/src/utils/isovist.cpp
@@ -320,7 +320,7 @@ void Isovist::calculateDerivs(std::vector<Point<float>>& endpoints)
     }
 
     scalars_[kMinLineDist] = std::sqrt(minDist);
-    scalars_[kMinLineNormal] = angle_sum(angle_to_point(endpoints[minIdx], endpoints[minIdx + otherSide]), M_PI_2);
+    scalars_[kMinLineNormal] = angle_sum(angle_to_point(endpoints[minIdx], endpoints[minIdx + otherSide]), PI_2_F);
 
     // Copy the derivative points on to the end of endpoints. Want to continuous regions, so do the [n,n+otherSide)
     // then [n+otherSide,end) [0,n)

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -37,7 +37,7 @@ utils_lib = static_library(
     utils_src,
     include_directories : vulcan_inc,
     link_with : [core_lib, math_lib],
-    dependencies : [arma_dep],
+    dependencies : [arma_dep, boost_dep],
 )
 
 subdir('tests')


### PR DESCRIPTION
Turn on C++-20 for Meson to enable experimenting with new features.

An unfortunate side-effect right now is that on ubuntu 20.04, you must manually change the wxString type to make it compatible with C++-20. See [this PR](https://github.com/wxWidgets/wxWidgets/commit/176b9dde903476d528688d2282fb2f5823c14f2f) for the changes that you need to apply.

As part of this PR, start using the new std::numbers mathematical constants, which allows for cleaning up the angle functions a bit by allowing type-specific constants as opposed to a mishmash of floats and doubles. Updating these functions created a cascade of changes throughout their uses.